### PR TITLE
Run infection only on changed files on CI

### DIFF
--- a/etc/travis/suites/application/script/test-infection
+++ b/etc/travis/suites/application/script/test-infection
@@ -3,7 +3,7 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../../bash/common.lib.sh"
 
 
-if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
+if [[ "${CI}" == "" ]]; then
     INFECTION_FILTER="";
 else
     git remote set-branches --add origin $TRAVIS_BRANCH;


### PR DESCRIPTION
Before this change, a merged build ran infection on every files.