### PR TITLE
Add sonata events to be able to include javascript with events

### DIFF
--- a/templates/backend/layout.html.twig
+++ b/templates/backend/layout.html.twig
@@ -47,4 +47,5 @@
 
 {% block javascripts %}
     {% include 'SyliusUiBundle::_javascripts.html.twig' with {'path': 'assets/backend/app.js'} %}
+    {{ sonata_block_render_event('sylius.admin.layout.javascripts') }}
 {% endblock %}

--- a/templates/frontend/layout.html.twig
+++ b/templates/frontend/layout.html.twig
@@ -37,6 +37,7 @@
 
 {% block javascripts %}
     <script type="text/javascript" src="{{ asset('assets/frontend/app.js', 'frontend') }}"></script>
+    {{ sonata_block_render_event('sylius.shop.layout.javascripts') }}
 {% endblock %}
 {% include '@SyliusUi/Modal/_confirmation.html.twig' %}
 </body>


### PR DESCRIPTION
I want to be able to create a plugin compatible with Sylius and Monofony.
In order to to that, it could be nice to add these events to fit with Sylius.

Admin : https://docs.sylius.com/en/1.6/cookbook/frontend/admin-js-and-css.html
```yaml
# config/services.yaml
services:
    app.block_event_listener.admin.layout.javascripts:
        class: Sylius\Bundle\UiBundle\Block\BlockEventListener
        arguments:
            - '@@App/Admin/_javascripts.html.twig'
        tags:
            - { name: kernel.event_listener, event: sonata.block.event.sylius.admin.layout.javascripts, method: onBlockEvent }
```

In front : 
```yaml
# config/services.yaml
services:
    app.block_event_listener.shop.layout.javascripts:
        class: Sylius\Bundle\UiBundle\Block\BlockEventListener
        arguments:
            - '@@App/Shop/_javascripts.html.twig'
        tags:
            - { name: kernel.event_listener, event: sonata.block.event.sylius.shop.layout.javascripts, method: onBlockEvent }
```