### PR TITLE
improve sonata block configuration

### DIFF
--- a/config/packages/sonata_block.yaml
+++ b/config/packages/sonata_block.yaml
@@ -1,4 +1,8 @@
 sonata_block:
-    default_contexts: [cms]
     blocks:
-        sonata.block.service.text: ~    
+        sonata.block.service.template:
+            settings:
+                customer: ~
+                form: ~
+                resource: ~
+                resources: ~


### PR DESCRIPTION
Actually we can't override sylius templates with the BlockEventListener